### PR TITLE
Add validate-schema github action

### DIFF
--- a/.github/workflows/validate-schema.yml
+++ b/.github/workflows/validate-schema.yml
@@ -18,38 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Create JSON schema file
-        run: |
-          cat > schema.json << 'EOL'
-          {
-            "$schema": "http://json-schema.org/draft-07/schema#",
-            "type": "object",
-            "patternProperties": {
-              "^[A-Za-z0-9\\s-]+$": {
-                "type": "object",
-                "properties": {
-                  "hex": {
-                    "type": "string",
-                    "pattern": "^#[0-9A-Fa-f]{6}$"
-                  },
-                  "aliases": {
-                    "type": "array",
-                    "items": {
-                      "type": "string",
-                      "pattern": "^[a-zA-Z0-9_-]+$"
-                    },
-                    "minItems": 1,
-                    "uniqueItems": true
-                  }
-                },
-                "required": ["hex", "aliases"],
-                "additionalProperties": false
-              }
-            },
-            "additionalProperties": false
-          }
-          EOL
-
       - name: Validate JSON Schema
         uses: cardinalby/schema-validator-action@v1
         with:

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "patternProperties": {
+    "^[A-Za-z0-9\\s-]+$": {
+      "type": "object",
+      "properties": {
+        "hex": {
+          "type": "string",
+          "pattern": "^#[0-9A-Fa-f]{6}$"
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_-]+$"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      },
+      "required": ["hex", "aliases"],
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
**Validations:**
- Protocol names can only contain alphanumeric characters, spaces, and hyphens
- Hex colors must be valid 6-digit hex codes with # prefix
- Aliases must be alphanumeric with underscores/hyphens allowed
- No duplicate aliases across different protocols
- No additional properties beyond what's defined in the schema

__________

**The action will now run automatically on PRs (targeting main) and pushes to main, failing if:**
- The JSON is malformed
- The schema is violated
- There are duplicate aliases
- Any hex colors are invalid
- Any protocol names contain invalid characters
- Any additional properties than are not allowed