### PR TITLE
Add brand colors for DeFi collateral assets (29 new entries + 9 aliases on existing protocols)

### DIFF
--- a/color-palettes.json
+++ b/color-palettes.json
@@ -597,11 +597,11 @@
   },
   "Lido": {
     "hex": "#4DB0F2",
-    "aliases": ["lido"]
+    "aliases": ["lido", "steth", "wsteth"]
   },
   "Coinbase": {
     "hex": "#0854FC",
-    "aliases": ["coinbase"]
+    "aliases": ["coinbase", "cbeth", "cbbtc"]
   },
   "Kraken": {
     "hex": "#5844DC",
@@ -633,7 +633,7 @@
   },
   "RocketPool": {
     "hex": "#FB8562",
-    "aliases": ["rocketpool"]
+    "aliases": ["rocketpool", "reth"]
   },
   "Celsius": {
     "hex": "#101464",
@@ -653,7 +653,7 @@
   },
   "Stakewise": {
     "hex": "#9082B3",
-    "aliases": ["stakewise"]
+    "aliases": ["stakewise", "oseth"]
   },
   "Bitstamp": {
     "hex": "#08FC9C",
@@ -717,11 +717,11 @@
   },
   "etherfi": {
     "hex": "#2F1769",
-    "aliases": ["etherfi"]
+    "aliases": ["etherfi", "weeth", "eeth"]
   },
   "Renzo": {
     "hex": "#C5FE5B",
-    "aliases": ["renzo"]
+    "aliases": ["renzo", "ezeth"]
   },
   "Swell": {
     "hex": "#2040CD",
@@ -954,5 +954,121 @@
   "flashloan": {
     "hex": "#e58606",
     "aliases": ["flashloan"]
+  },
+  "OETH": {
+    "hex": "#0476F0",
+    "aliases": ["oeth", "origin_eth"]
+  },
+  "rsETH": {
+    "hex": "#075B5B",
+    "aliases": ["rseth"]
+  },
+  "ETH Plus": {
+    "hex": "#84C8FE",
+    "aliases": ["eth plus"]
+  },
+  "ETHx": {
+    "hex": "#8D66B3",
+    "aliases": ["ethx"]
+  },
+  "mETH": {
+    "hex": "#F4596D",
+    "aliases": ["meth"]
+  },
+  "sfrxETH": {
+    "hex": "#2563EB",
+    "aliases": ["sfrxeth"]
+  },
+  "frxETH": {
+    "hex": "#3B82F6",
+    "aliases": ["frxeth"]
+  },
+  "tETH": {
+    "hex": "#1CADAF",
+    "aliases": ["teth"]
+  },
+  "savETH": {
+    "hex": "#3A14A3",
+    "aliases": ["saveth"]
+  },
+  "ARM WETH eETH": {
+    "hex": "#9F52EA",
+    "aliases": ["arm-weth-eeth", "arm weth eeth"]
+  },
+  "ARM WETH stETH": {
+    "hex": "#A75EEC",
+    "aliases": ["arm-weth-steth", "arm weth steth"]
+  },
+  "WBTC": {
+    "hex": "#F09547",
+    "aliases": ["wbtc"]
+  },
+  "tBTC": {
+    "hex": "#1D2229",
+    "aliases": ["tbtc"]
+  },
+  "LBTC": {
+    "hex": "#5ECBC0",
+    "aliases": ["lbtc"]
+  },
+  "sUSDS": {
+    "hex": "#59D294",
+    "aliases": ["susds"]
+  },
+  "sUSDe": {
+    "hex": "#CDCDCD",
+    "aliases": ["susde", "pt-susde"]
+  },
+  "syrupUSDC": {
+    "hex": "#FB8042",
+    "aliases": ["syrupusdc"]
+  },
+  "syrupUSDT": {
+    "hex": "#FD905E",
+    "aliases": ["syrupusdt"]
+  },
+  "savUSD": {
+    "hex": "#3A14A3",
+    "aliases": ["savusd", "pt-savusd-14may2026"]
+  },
+  "stcUSD": {
+    "hex": "#D1F019",
+    "aliases": ["stcusd"]
+  },
+  "DUSD": {
+    "hex": "#DD2B2C",
+    "aliases": ["dusd"]
+  },
+  "siUSD": {
+    "hex": "#222223",
+    "aliases": ["siusd"]
+  },
+  "jrUSDe": {
+    "hex": "#9B7AFF",
+    "aliases": ["jrusde"]
+  },
+  "sNUSD": {
+    "hex": "#D7E538",
+    "aliases": ["snusd", "pt-snusd-4jun2026"]
+  },
+  "XAUt": {
+    "hex": "#DAB25C",
+    "aliases": ["xaut"]
+  },
+  "VBILL": {
+    "hex": "#16468E",
+    "aliases": ["vbill"]
+  },
+  "STAC": {
+    "hex": "#2B9CAE",
+    "aliases": ["stac"]
+  },
+  "NUSD": {
+    "hex": "#2E4D40",
+    "aliases": ["nusd"]
+  },
+  "srNUSD": {
+    "hex": "#A9B530",
+    "aliases": ["srnusd", "pt-srnusd-28may2026"]
   }
 }


### PR DESCRIPTION
Adds brand colors for **38 tokens** commonly used as DeFi collateral (Morpho, Euler, Gearbox vaults). These currently render with random auto-colors on collateral-exposure donuts; this PR brings them in line with the existing palette.

### Two patterns

**1. Token's issuer protocol already exists → add as alias on existing entry** (no hex changes, inherits brand color):

| Existing entry | New aliases | Hex (unchanged) |
|---|---|---|
| `Lido` | `steth`, `wsteth` | `#4DB0F2` |
| `Coinbase` | `cbeth`, `cbbtc` | `#0854FC` |
| `RocketPool` | `reth` | `#FB8562` |
| `etherfi` | `weeth`, `eeth` | `#2F1769` |
| `Stakewise` | `oseth` | `#9082B3` |
| `Renzo` | `ezeth` | `#C5FE5B` |

**2. Token has no parent entry → add as new entry** (29 entries):

| Symbol | Hex |
|---|---|
| `OETH` | `#0476F0` |
| `rsETH` | `#075B5B` |
| `ETH Plus` | `#84C8FE` |
| `ETHx` | `#8D66B3` |
| `mETH` | `#F4596D` |
| `sfrxETH` | `#2563EB` |
| `frxETH` | `#3B82F6` |
| `tETH` | `#1CADAF` |
| `savETH` | `#3A14A3` |
| `ARM WETH eETH` | `#9F52EA` |
| `ARM WETH stETH` | `#A75EEC` |
| `WBTC` | `#F09547` |
| `tBTC` | `#1D2229` |
| `LBTC` | `#5ECBC0` |
| `sUSDS` | `#59D294` |
| `sUSDe` | `#CDCDCD` |
| `syrupUSDC` | `#FB8042` |
| `syrupUSDT` | `#FD905E` |
| `savUSD` | `#3A14A3` |
| `stcUSD` | `#D1F019` |
| `DUSD` | `#DD2B2C` |
| `siUSD` | `#222223` |
| `jrUSDe` | `#9B7AFF` |
| `sNUSD` | `#D7E538` |
| `NUSD` | `#2E4D40` |
| `srNUSD` | `#A9B530` |
| `XAUt` | `#DAB25C` |
| `VBILL` | `#16468E` |
| `STAC` | `#2B9CAE` |

### Skipped (already in palette)

WETH (alias of `Ethereum`), USDC, USDT, DAI, USDS, USDe, RLUSD.

### Pendle PTs

Added as aliases on the underlying (e.g. `pt-susde` → `sUSDe`, `pt-snusd-4jun2026` → `sNUSD`) so chart colors track the underlying yield source rather than "Pendle as a brand."

### Strata tranches

`jrUSDe` (junior USDe) and `srNUSD` (senior NUSD) use underlying-family shifts so they read as variants of the underlying on charts (USDe purple lightened, sNUSD yellow-green darkened).

### Sources

- DeFiLlama per-token logos (dominant color via k-means clustering)
- Official brand palettes: Frax (`sfrxETH`/`frxETH` Blue 600/500), Lombard (`LBTC` teal-mint), Avant (`savETH`/`savUSD` deep purple from brand kit SVG)
- CoinGecko logo for `VBILL` (proper VanEck dark blue)

### Validation

Schema-valid (268 total entries). Diff: 122 insertions / 6 deletions, original formatting preserved.