### PR TITLE
add buckets

### DIFF
--- a/color-palettes.json
+++ b/color-palettes.json
@@ -1,4 +1,24 @@
 {
+  "0-1": {
+    "hex": "#4C8DF0",
+    "aliases": ["0-1"]
+  },
+  "1-100": {
+    "hex": "#2BC4B0",
+    "aliases": ["1-100"]
+  },
+  "100-10k": {
+    "hex": "#A8D24B",
+    "aliases": ["100-10k"]
+  },
+  "10k-100k": {
+    "hex": "#F2A03C",
+    "aliases": ["10k-100k"]
+  },
+  "100k plus": {
+    "hex": "#EA5247",
+    "aliases": ["100k plus"]
+  },
   "FTX": {
     "hex": "#11A9BC",
     "aliases": ["ftx"]


### PR DESCRIPTION
I added 5 value-bucket entries to color-palettes.json with a cool→warm spectral ramp (ordered + dark-mode-friendly):
0-1: #4C8DF0 blue
1-100: #2BC4B0 teal
100-10k: #A8D24B yellow-green
10k-100k: #F2A03C orange
100k plus: #EA5247 red
Key point: I used schema-safe labels (no $, <, or +, which the schema rejects) instead of the original <$1, $1-$100, … forms.