### PR TITLE
Split "Unknown" out of "Other" into its own color

### DIFF
--- a/color-palettes.json
+++ b/color-palettes.json
@@ -1672,8 +1672,12 @@
     "aliases": ["usd"]
   },
   "Other": {
+    "hex": "#616161",
+    "aliases": ["other"]
+  },
+  "Unknown": {
     "hex": "#BDBDBD",
-    "aliases": ["other", "unidentified", "unknown"]
+    "aliases": ["unknown", "unidentified"]
   },
   "unidentified_smart_contract": {
     "hex": "#9E9E9E",


### PR DESCRIPTION
"unknown" and "unidentified" were aliases of "Other", so all three resolved to the same hex. Group "unknown"/"unidentified" into a separate "Unknown" entry so the two buckets are distinct:
- Other: #616161 (Material Grey 700)
- Unknown: #BDBDBD (its original grey), aliases unknown, unidentified