### PR TITLE
Add Cards, Agentic, and Commerce entries

### DIFF
--- a/color-palettes.json
+++ b/color-palettes.json
@@ -19,6 +19,18 @@
     "hex": "#EA5247",
     "aliases": ["100k plus"]
   },
+  "Cards": {
+    "hex": "#4C8DF0",
+    "aliases": ["cards"]
+  },
+  "Agentic": {
+    "hex": "#2BC4B0",
+    "aliases": ["agentic"]
+  },
+  "Commerce": {
+    "hex": "#F2A03C",
+    "aliases": ["commerce"]
+  },
   "FTX": {
     "hex": "#11A9BC",
     "aliases": ["ftx"]


### PR DESCRIPTION
Add three payment-category entries using colors from the existing bucket palette:
- Cards: #4C8DF0 (blue)
- Agentic: #2BC4B0 (teal)
- Commerce: #F2A03C (orange)