### PR TITLE
Add Monad and MegaETH palettes, update Robinhood

### DIFF
--- a/color-palettes.json
+++ b/color-palettes.json
@@ -1599,6 +1599,14 @@
     "hex": "#90019B",
     "aliases": ["tac"]
   },
+  "Monad": {
+    "hex": "#6E54FF",
+    "aliases": ["monad", "mon"]
+  },
+  "MegaETH": {
+    "hex": "#DFD9D9",
+    "aliases": ["megaeth", "mega"]
+  },
   "USDT": {
     "hex": "#26A17B",
     "aliases": ["usdt", "tether"]

--- a/color-palettes.json
+++ b/color-palettes.json
@@ -744,7 +744,7 @@
     "aliases": ["bibox"]
   },
   "Robinhood": {
-    "hex": "#00C805",
+    "hex": "#CCFF00",
     "aliases": ["robinhood"]
   },
   "ProBit": {


### PR DESCRIPTION
## Summary
- Add **Monad** with `#6E54FF`, the primary purple from [Monad's current brand kit](https://www.monad.xyz/brand-and-media-kit) (the existing "Monad Testnet" entry keeps the older `#836EF9`), aliases `monad`, `mon`
- Add **MegaETH** with `#DFD9D9` ("Full Moon" from the [MegaETH brand kit](https://www.megaeth.com/brand-kit)), aliases `megaeth`, `mega`
- Update **Robinhood** from `#00C805` to `#CCFF00` — the "Robin Neon" electric yellow-green from [Robinhood's 2024 rebrand](https://newsroom.aboutrobinhood.com/a-visual-identity-that-better-reflects-our-vision/)

The new chain entries are appended at the end of the chains block, following the pattern of the previous chain batch (#23).

## Verification
- File validates against `schema.json` constraints (6-digit hex, non-empty unique aliases, no extra fields)
- Case-insensitive duplicate-alias check (same as CI) returns no collisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)